### PR TITLE
NDS-806: Fix broken dspace auto-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 # DSpace image
 #
 
-FROM openjdk:7u111
+FROM maven:3.3.9-jdk-7
+
+# Build Arguments
+ARG TOMCAT_VERSION="8.0.42"
+ARG DSPACE_VERSION="5.4"
 
 # Environment variables
 ENV CATALINA_HOME=/usr/local/tomcat DSPACE_HOME=/dspace
@@ -12,14 +16,17 @@ WORKDIR /tmp
 
 # Install runtime and dependencies
 RUN apt-get update && apt-get install -y vim ant nmap postgresql-client \
-    && mkdir -p maven dspace "$CATALINA_HOME" \
-    && curl -fSL http://apache.mirrors.tds.net/tomcat/tomcat-8/v8.0.41/bin/apache-tomcat-8.0.41.tar.gz -o tomcat.tar.gz \
-    && curl -fSL http://apache.mirror.iweb.ca/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -o maven.tar.gz \
-    && curl -L https://github.com/DSpace/DSpace/releases/download/dspace-5.4/dspace-5.4-release.tar.gz -o dspace.tar.gz \
+    && apt-get -qq autoremove \
+    && apt-get -qq autoclean \
+    && apt-get -qq clean all \
+    && rm -rf /var/cache/apk/* /tmp/* /var/lib/apt/lists/*
+
+RUN mkdir -p dspace "$CATALINA_HOME" \
+    && curl -fSL http://apache.mirrors.tds.net/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz -o tomcat.tar.gz \
+    && curl -L https://github.com/DSpace/DSpace/releases/download/dspace-${DSPACE_VERSION}/dspace-${DSPACE_VERSION}-release.tar.gz -o dspace.tar.gz \
     && tar -xvf tomcat.tar.gz --strip-components=1 -C "$CATALINA_HOME" \
-    && tar -xvf maven.tar.gz --strip-components=1  -C maven \
     && tar -xvf dspace.tar.gz --strip-components=1  -C dspace \
-    && cd dspace && ../maven/bin/mvn package \
+    && cd dspace && mvn package \
     && cd dspace/target/dspace-installer \
     && ant init_installation init_configs install_code copy_webapps \
     && rm -fr "$CATALINA_HOME/webapps" && mv -f /dspace/webapps "$CATALINA_HOME" \


### PR DESCRIPTION
* Split the big build step into 2 steps
* Use maven base image instead of installing maven manually
* Parameterize tomcat / dspace version numbers
* Bump tomcat version up to 8.0.42 (since 8.0.41 now throws an HTTP 404)

See: https://opensource.ncsa.illinois.edu/jira/browse/NDS-806